### PR TITLE
ML-426 Job hangs or runs out of memory when LOOP depth exceeds 68

### DIFF
--- a/LT_Types.ecl
+++ b/LT_Types.ecl
@@ -25,7 +25,7 @@ EXPORT LT_Types := MODULE
   /**
     * Type definition for the node id field representing a tree node's id
     */
-  EXPORT t_NodeId := t_FieldNumber;
+  EXPORT t_NodeId := UNSIGNED8;
   /**
     * Definition of the meaning of the indexes of the Forest Model variables.
     * <p>Ind1 enumerates the first index, which


### PR DESCRIPTION
Change t_NodeId to UNSIGNED8
Modify RF_Classification and RF_Regression to explicitly test for near overflow at 2**48
Eliminate unused code block (findBestSplitx) in RF_Classification (cleanup)

Signed-off-by: Roger Dev <Roger.Dev@LexisNexisRisk.com>