### PR TITLE
ML-528 Add "#ONWARNING(30004, ignore)" to test cases in LearningTree bundle.

### DIFF
--- a/ecl/ClassificationTestModified.ecl
+++ b/ecl/ClassificationTestModified.ecl
@@ -15,6 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
+#ONWARNING(30004, ignore); // Do not report execute time skew warning
 #ONWARNING(2007, ignore);
 #ONWARNING(4531, ignore);
 #ONWARNING(4550, ignore);

--- a/ecl/RegressionTestModified.ecl
+++ b/ecl/RegressionTestModified.ecl
@@ -15,6 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
+#ONWARNING(30004, ignore); // Do not report execute time skew warning
 #ONWARNING(4550, ignore);
 
 // Modified version of the testCovTypeReg test file that works with the


### PR DESCRIPTION
Add "#ONWARNING(30004, ignore);" to avoid warning for execute time skew into
  - ClassificationTestModified.ecl
  - RegressionTestModified.ecl

(Based on Shamser's comment for HPCC-31151)
Tested locally